### PR TITLE
Add function to clear transient storage array

### DIFF
--- a/src/mixin/TransientStorageArray.sol
+++ b/src/mixin/TransientStorageArray.sol
@@ -123,4 +123,13 @@ abstract contract TransientStorageArray {
             mstore(dataMemoryLocation, byteLength)
         }
     }
+
+    /// @notice Clear all the content of the transient storage array, leaving
+    /// in its stead an empty array
+    /// @dev The actual transient storage array content isn't actually reset to
+    /// zero bytes, however this data cannot be accessed and can be overwritten
+    /// at a later point
+    function clearTransientStorageArray() internal {
+        length = 0;
+    }
 }

--- a/test/mixin/TransientStorageArray.t.sol
+++ b/test/mixin/TransientStorageArray.t.sol
@@ -83,8 +83,20 @@ contract TransientStorageArrayTest is Test {
         checkRoundTrip(data);
     }
 
-    function testFuzz_canOverrideArray(bytes memory firstArray, bytes memory secondArray) private {
+    function testFuzz_canOverrideArray(bytes memory firstArray, bytes memory secondArray) external {
         assertEq(executor.storeTwiceAndRead(firstArray, secondArray), secondArray);
+    }
+
+    function testFuzz_clearingDoesNotAffectFutureStore(bytes memory data) external {
+        assertEq(executor.storeClearAndRead(data), hex"");
+    }
+
+    function testFuzz_clearedArrayHasZeroLength(bytes memory data) external {
+        assertEq(executor.storeClearReturnLength(data), 0);
+    }
+
+    function testFuzz_clearingDoesNotAffectFutureStore(bytes memory firstArray, bytes memory secondArray) external {
+        assertEq(executor.storeClearStoreAndRead(firstArray, secondArray), secondArray);
     }
 
     function testFuzz_settingTransientVariablesDoesNotChangeArray(bytes memory data) external {

--- a/test/mixin/TransientStorageArray/ExposedTransientStorageArray.sol
+++ b/test/mixin/TransientStorageArray/ExposedTransientStorageArray.sol
@@ -18,6 +18,10 @@ contract ExposedTransientStorageArray is TransientStorageArray {
     function length() external view returns (uint256) {
         return transientStorageArrayLength();
     }
+
+    function clear() external {
+        clearTransientStorageArray();
+    }
 }
 
 uint256 constant BYTES_IN_WORD = 32;
@@ -47,6 +51,25 @@ contract StoreAndRead {
     function storeTwiceAndRead(bytes memory first, bytes memory second) external returns (bytes memory) {
         tsa.store(first);
         tsa.store(second);
+        return tsa.read();
+    }
+
+    function storeClearReturnLength(bytes memory data) external returns (uint256) {
+        tsa.store(data);
+        tsa.clear();
+        return tsa.length();
+    }
+
+    function storeClearAndRead(bytes memory data) external returns (bytes memory) {
+        tsa.store(data);
+        tsa.clear();
+        return tsa.read();
+    }
+
+    function storeClearStoreAndRead(bytes memory data1, bytes memory data2) external returns (bytes memory) {
+        tsa.store(data1);
+        tsa.clear();
+        tsa.store(data2);
         return tsa.read();
     }
 


### PR DESCRIPTION
Code to clear the transient storage array. For gas efficiency, the actual transient storage is not cleared, however it's inaccessible after clearing. This function allows the transient storage array to be used as some kind of reentrancy guard (see #2).

Note that I also sneaked in a bug fix: a test was marked as `private` and not `external`, meaning that it wasn't actually being run. As a future improvement process, we should check with a linter that functions of the form `test_*` are either `public` or `external`.

### How to test

New fuzz tests.