### PR TITLE
Drop "wrapper" in naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Flash-Loan Wrapper Solver
+## Flash-Loan Router
 
 A smart contract that allows CoW Protocol solvers to call `settle` in the context of a flash-loan contract.
 

--- a/test/e2e/lib/CowProtocolInteraction.sol
+++ b/test/e2e/lib/CowProtocolInteraction.sol
@@ -32,13 +32,13 @@ library CowProtocolInteraction {
         });
     }
 
-    function wrapperApprove(IBorrower solverWrapper, IERC20 token, address spender, uint256 amount)
+    function borrowerApprove(IBorrower borrower, IERC20 token, address spender, uint256 amount)
         internal
         pure
         returns (ICowSettlement.Interaction memory)
     {
         return ICowSettlement.Interaction({
-            target: address(solverWrapper),
+            target: address(borrower),
             value: 0,
             callData: abi.encodeCall(IBorrower.approve, (token, spender, amount))
         });


### PR DESCRIPTION
At first, borrowers were independent contracts and were called "solver wrappers." There are some leftovers of this naming convention, especially in the e2e tests. This PR makes the naming consistent across the repo.

### How to test

Search for "wrapper" in the repo and only find an unrelated entry in a vendored library.