### PR TITLE
Update ICowSettlement.sol and IFlashLoanRouter.sol interfaces

### DIFF
--- a/src/interface/ICowSettlement.sol
+++ b/src/interface/ICowSettlement.sol
@@ -38,7 +38,7 @@ interface ICowSettlement {
     /// settlements. Any valid authenticator implements an isSolver method
     /// called by the onlySolver modifier below.
     /// @dev See <https://github.com/cowprotocol/contracts/blob/9c1984b864d0a6703a877a088be6dac56450808c/src/contracts/GPv2Settlement.sol#L28-L32>.
-    function authenticator() external returns (address);
+    function authenticator() external view returns (address);
 
     /// @notice Settle the specified orders at a clearing price. Note that it is
     /// the responsibility of the caller to ensure that all GPv2 invariants are

--- a/src/interface/IFlashLoanRouter.sol
+++ b/src/interface/IFlashLoanRouter.sol
@@ -41,9 +41,9 @@ interface IFlashLoanRouter {
 
     /// @notice The settlement contract supported by this router. This is the
     /// contract that will be called when the settlement is executed.
-    function settlementContract() external returns (ICowSettlement);
+    function settlementContract() external view returns (ICowSettlement);
 
     /// @notice The settlement authenticator contract for CoW Protocol. This
     /// contract determines who the solvers for CoW Protocol are.
-    function settlementAuthentication() external returns (ICowAuthentication);
+    function settlementAuthentication() external view returns (ICowAuthentication);
 }


### PR DESCRIPTION
Added the missing `view` keyword to:

1. `function settlementContract()` in `IFlashLoanRouter.sol`
2. `function settlementAuthentication()` in IFlashLoanRouter.sol`
3. `function authenticator()` in `ICowSettlement.sol`