### PR TITLE
Document pitfalls of using optimized libraries

### DIFF
--- a/src/library/Bytes.sol
+++ b/src/library/Bytes.sol
@@ -35,9 +35,15 @@ library Bytes {
 
     /// @notice Return the location of the content of an array in memory. Note
     /// that the array length is not part of the content.
+    /// @dev This function returns an incorrect pointer if the input array is
+    /// located to a memory slot close to the maximum value of 2²⁵⁶.
+    /// The content or length of such an array cannot be accessed without
+    /// causing an out-of-gas revert. However, such an array can still be
+    /// created using assembly. If you're using this function, you must make
+    /// sure that the bytes array you're using doesn't trigger this edge case.
     /// @param array A bytes array.
     /// @return ref The location in memory of the content of the array.
-    function memoryPointerToContent(bytes memory array) internal pure returns (uint256 ref) {
+    function unsafeMemoryPointerToContent(bytes memory array) internal pure returns (uint256 ref) {
         // Unchecked: arrays allocated by Solidity cannot cause an overflow,
         // since a transaction would run out of gas long before reaching the
         // length needed for an overflow. Arrays that were manually allocated

--- a/test/library/Bytes.t.sol
+++ b/test/library/Bytes.t.sol
@@ -53,7 +53,7 @@ contract BytesTest is Test {
     function test_pointsToMemoryContent() external pure {
         bytes memory array = hex"3133333333333333333333333333333333333333333333333333333333333333333333333333333337";
         uint256 content;
-        uint256 pointer = array.memoryPointerToContent();
+        uint256 pointer = array.unsafeMemoryPointerToContent();
         assembly ("memory-safe") {
             content := mload(pointer)
         }

--- a/test/library/Loan.t.sol
+++ b/test/library/Loan.t.sol
@@ -29,12 +29,12 @@ contract RoundTripEncoder {
 
     function allocate() private pure returns (Loan.EncodedData) {
         bytes memory encodedData = allocateToBytes();
-        return Loan.EncodedData.wrap(encodedData.memoryPointerToContent());
+        return Loan.EncodedData.wrap(encodedData.unsafeMemoryPointerToContent());
     }
 
     function encode(Loan.Data calldata loanRequest) public pure returns (bytes memory encodedData) {
         encodedData = allocateToBytes();
-        Loan.EncodedData.wrap(encodedData.memoryPointerToContent()).store(loanRequest);
+        Loan.EncodedData.wrap(encodedData.unsafeMemoryPointerToContent()).store(loanRequest);
     }
 
     function storeAndDecode(Loan.Data calldata loanRequest) external pure returns (Loan.Data memory) {


### PR DESCRIPTION
PR #30 drops an assumption on how an array is laid out in memory that could cause an issue if it's laid out at a very large memory location.

This PR leaves the code as-is instead and documents it more clearly to point out this potential issue, but avoids the gas overhead of adding the extra check.

<details><summary>Context from linked PR</summary>

During the G0 audit of our code, we received a [comment](https://cowservices.slack.com/archives/CM1HPMCE5/p1742413286297359?thread_ts=1741089683.018059&cid=CM1HPMCE5) by our auditor pointing out that the code makes an assumption that might get invalidated if the current code changes (i.e., a potential foot gun).

The bad case can happen when the `Bytes` library is used on an assembly-created array that has an extremely high memory location. Such array cannot be read/written/accessed in any way but can still be created (see test).

This PR implements the change suggested by the auditor. Since the function is used often, the overhead of the overflow check is non-negligible (~1kgas). I'm personally unsure if we should make this change, considering that I can't think of any realistic case where such an array could be created (without having a malicious user of the library).

My weak vote goes for keeping things like they are right now. We don't expect other users to use this library (note that the borrowers, which we expect other protocols to implement, don't rely on this library, not even indirectly through `Borrower`. So the largest risk would be on us when making changes to the router.

This PR is mainly here for discussion.


<details><summary>Full comment</summary>

> It is true that this can overflow only if a malicious bytes array is crafted and given to this function and that reading/writing to such an array will cause a revert. But you can still craft such an array, never read/write to it, and pass it to this function which will result in an incorrect pointer with undefined behaviour. This is not possible in the current way the function is used.
> If this function is not gonna be re-used in another way in the future that's fine but I would still add an overflow check (or simply read the array to make sure it's not empty).

</details>

</details>

Closes #20.

### How to test

Check that the actual code didn't change and the comments make sense.