### PR TITLE
Workaround for checking fmt on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
           forge --version
 
       - name: Run Forge fmt
-        # Reenable formatting checks once the following issue is resolved:
-        # https://github.com/foundry-rs/foundry/issues/9088
-        continue-on-error: true
         run: |
           forge fmt --check
         id: fmt

--- a/foundry.toml
+++ b/foundry.toml
@@ -23,3 +23,12 @@ sort_imports = true
 [profile.ci]
 deny_warnings = true
 fuzz.seed = '0'
+
+[profile.ci.fmt]
+ignore = [
+  # Foundry's fmt doesn't support the `transient` keyword on variables.
+  # We ignore all files that have that keyword in them until Foundry fixes this
+  # issue on their end.
+  # https://github.com/foundry-rs/foundry/issues/9088
+  "src/FlashLoanRouter.sol"
+]


### PR DESCRIPTION
We're currently ignoring the formatting check on CI because of a Foundry issue.
With these changes, we ignore only the only file that are affected by that issue.

The change only apply to the `ci` profile because I find it handy to format the affected file by just removing the `transient` keywords, format that file, and then put them back.

See how `fmt` configuration works [here](https://book.getfoundry.sh/config/#standalone-sections).

### How to test

Check out CI logs and confirm `cargo fmt` is working as expected.