### PR TITLE
feat: remove the preHook flag

### DIFF
--- a/test/e2e/HelperContract.t.sol
+++ b/test/e2e/HelperContract.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8;
 
-import {Test, Vm} from "forge-std/Test.sol";
+import {Test, Vm, console} from "forge-std/Test.sol";
 
 import {AaveBorrower, IAavePool} from "src/AaveBorrower.sol";
 
@@ -132,7 +132,7 @@ contract E2eHelperContract is Test {
         GPv2Order.Data memory order = GPv2Order.Data({
             sellToken: Constants.AWETH,
             buyToken: Constants.ADAI,
-            receiver: user,
+            receiver: _helperAddress,
             sellAmount: 10 ether - _flashloanFee,
             buyAmount: 2_500 ether,
             validTo: type(uint32).max,


### PR DESCRIPTION
### GIST
Backend can't provide flashloan assets to fulfill the verification of the validity of the order.
I ended up removing the preHook check from the isValidSignature.

### THE FIX
instead of the order sending the funds to the user, now the order output goes to the contract.
To avoid an attacker forcing the user to take the limit price without the positive slippage, we are checking that the preHook was called.

If the attacker calls postHook() to force the limit price, they would need to donate atokens to the helper contract.