### PR TITLE
Record Ink deployment in networks.json

### DIFF
--- a/broadcast/networks-manual.json
+++ b/broadcast/networks-manual.json
@@ -3,18 +3,30 @@
     "232": {
       "address": "0x7d9c4dee56933151bc5c909cfe09def0d315cb4a",
       "transactionHash": "0xc848728231cbdb4ec3357b15f72110fe917b0df13757ae9159bfd36c5a13b355"
+    },
+    "57073": {
+      "address": "0x7d9c4dee56933151bc5c909cfe09def0d315cb4a",
+      "transactionHash": "0xb32a71421911381356f9d21b44fc8d983dbc4c023db980754bd30b620f3a04e2"
     }
   },
   "ERC3156Borrower": {
     "232": {
       "address": "0x47d71b4b3336ab2729436186c216955f3c27cd04",
       "transactionHash": "0xfb19da501e4a3c874d1cf1458a277cf56846347181a7e25974260f21015ff497"
+    },
+    "57073": {
+      "address": "0x47d71b4b3336ab2729436186c216955f3c27cd04",
+      "transactionHash": "0x6926f2ce4386afa30d164655b8cacb52de47e9a3bdaa6276f6088b7c7fb21c72"
     }
   },
   "FlashLoanRouter": {
     "232": {
       "address": "0x9da8b48441583a2b93e2ef8213aad0ec0b392c69",
       "transactionHash": "0xe162007fa0e73c290e08b811f5b9144634a72551973ff299bd7b1c3e7d09d63b"
+    },
+    "57073": {
+      "address": "0x9da8b48441583a2b93e2ef8213aad0ec0b392c69",
+      "transactionHash": "0x88e01a104196caa51e10f09cf3326eb5ea3988def13e1823786a97155cf0fb62"
     }
   }
 }

--- a/networks.json
+++ b/networks.json
@@ -36,6 +36,10 @@
       "address": "0x7d9c4dee56933151bc5c909cfe09def0d315cb4a",
       "transactionHash": "0x9eabc29bf174869af986067f0734d3a43c3fa52efa23137557cde10ff3ab26cb"
     },
+    "57073": {
+      "address": "0x7d9c4dee56933151bc5c909cfe09def0d315cb4a",
+      "transactionHash": "0xb32a71421911381356f9d21b44fc8d983dbc4c023db980754bd30b620f3a04e2"
+    },
     "59144": {
       "address": "0x7d9c4dee56933151bc5c909cfe09def0d315cb4a",
       "transactionHash": "0x139ba936c8f02a189d9269c8d1418a44a4c201c5c5236027a2e11c6ebbce1a7c"
@@ -86,6 +90,10 @@
       "address": "0x47d71b4b3336ab2729436186c216955f3c27cd04",
       "transactionHash": "0xe46adc4b1ecdace98c3dc42ac492aaa9a7dd2f0ad5723b5ae58175bf99e46df0"
     },
+    "57073": {
+      "address": "0x47d71b4b3336ab2729436186c216955f3c27cd04",
+      "transactionHash": "0x6926f2ce4386afa30d164655b8cacb52de47e9a3bdaa6276f6088b7c7fb21c72"
+    },
     "59144": {
       "address": "0x47d71b4b3336ab2729436186c216955f3c27cd04",
       "transactionHash": "0xf180a97a5225ef9d997740a4c1a0d24831f84516f307934801c4a26b55b59734"
@@ -135,6 +143,10 @@
     "56": {
       "address": "0x9da8b48441583a2b93e2ef8213aad0ec0b392c69",
       "transactionHash": "0x154dc75d07f933b7f7a486bb8b87f93484d8f926bc874602915ff3a00eca82ed"
+    },
+    "57073": {
+      "address": "0x9da8b48441583a2b93e2ef8213aad0ec0b392c69",
+      "transactionHash": "0x88e01a104196caa51e10f09cf3326eb5ea3988def13e1823786a97155cf0fb62"
     },
     "59144": {
       "address": "0x9da8b48441583a2b93e2ef8213aad0ec0b392c69",


### PR DESCRIPTION
## Description

All three contracts are already live on Ink (chain 57073) at the canonical CREATE2 addresses, but the repo didn't list them. This adds Ink to `networks.json`.

| Contract | Address | Creation tx |
|---|---|---|
| FlashLoanRouter | `0x9da8B48441583a2b93e2eF8213aAD0EC0b392C69` | [`0x88e01a10…`](https://explorer.inkonchain.com/tx/0x88e01a104196caa51e10f09cf3326eb5ea3988def13e1823786a97155cf0fb62) |
| AaveBorrower | `0x7d9C4DeE56933151Bc5C909cfe09DEf0d315CB4A` | [`0xb32a7142…`](https://explorer.inkonchain.com/tx/0xb32a71421911381356f9d21b44fc8d983dbc4c023db980754bd30b620f3a04e2) |
| ERC3156Borrower | `0x47d71b4B3336AB2729436186C216955F3C27cD04` | [`0x6926f2ce…`](https://explorer.inkonchain.com/tx/0x6926f2ce4386afa30d164655b8cacb52de47e9a3bdaa6276f6088b7c7fb21c72) |

The deployment wasn't run from this repo, so there are no broadcast files for it. Following the README, the entries go into `broadcast/networks-manual.json` and `networks.json` is regenerated from it. The `networks.json` diff is additive only.

Note that the deployer EOA was `0x05C5494572E4aB2d48D3AB3aAF6bD4e7b1c98382`, not the `0xcff6667d…` deployer used for Linea and Plasma. That has no effect on the resulting addresses or code — CREATE2 with a fixed salt — but it means these were deployed by someone outside the team, hence the checks below.

> **Don't diff `cast code` against `out/*.json` `deployedBytecode.object` — it will never match.** Immutables (`settlementContract`, `authenticator`, `router`) are written into runtime code at construction, while the build artifact carries zeroed placeholders for them. Compare chain-to-chain (checks 1–2) or compare *creation* code (check 3), which has no placeholders.

## Test plan

Set the RPCs once; all blocks below are copy-pasteable as-is and print `OK`/`FAIL` per contract.

```sh
export INK_RPC=https://rpc-gel.inkonchain.com
export MAINNET_RPC=https://ethereum-rpc.publicnode.com
```

### 1. Runtime code is identical to mainnet (no build needed)

```sh
for addr in 0x9da8B48441583a2b93e2eF8213aAD0EC0b392C69 \
            0x7d9C4DeE56933151Bc5C909cfe09DEf0d315CB4A \
            0x47d71b4B3336AB2729436186C216955F3C27cD04; do
  [ "$(cast code $addr --rpc-url $INK_RPC)" = "$(cast code $addr --rpc-url $MAINNET_RPC)" ] \
    && echo "OK   $addr matches mainnet" || echo "FAIL $addr differs from mainnet"
done
```

All three match byte-for-byte, immutables included — the immutable values happen to be the same on both chains, so there is no per-chain divergence at all.

### 2. Creation code is identical to mainnet's

Compares the full calldata (`salt ‖ creation code ‖ constructor args`) sent to the CREATE2 factory `0x4e59b448…` on each chain:

```sh
while read -r name mainnet_tx ink_tx; do
  m=$(cast tx "$mainnet_tx" --rpc-url $MAINNET_RPC --json | jq -r .input)
  i=$(cast tx "$ink_tx"     --rpc-url $INK_RPC     --json | jq -r .input)
  [ "$m" = "$i" ] && echo "OK   $name init code matches mainnet" || echo "FAIL $name init code differs"
done <<'TXS'
FlashLoanRouter 0x7f889b493b1e1c4b25dcc5b5022cc379a5f9dc0dd7b9e2b2d7c6f9cfc84c3d97 0x88e01a104196caa51e10f09cf3326eb5ea3988def13e1823786a97155cf0fb62
AaveBorrower    0x92abe52bb5530c028180561f2bcbea24efd1feefdbe176eb72812034060935df 0xb32a71421911381356f9d21b44fc8d983dbc4c023db980754bd30b620f3a04e2
ERC3156Borrower 0x92e1f09f9dde32cc2db062e8923094759fa1219101de7681723838f47fb2f3fb 0x6926f2ce4386afa30d164655b8cacb52de47e9a3bdaa6276f6088b7c7fb21c72
TXS
```

### 3. Creation code matches this repo's source (optional, needs `forge build`)

```sh
forge build
while read -r name artifact arg ink_tx; do
  expected="0x$(printf '%064x' 93)$(jq -r '.bytecode.object' "out/$artifact" | cut -c3-)$(cast abi-encode 'c(address)' "$arg" | cut -c3-)"
  onchain=$(cast tx "$ink_tx" --rpc-url $INK_RPC --json | jq -r .input)
  [ "$expected" = "$onchain" ] && echo "OK   $name matches source" || echo "FAIL $name differs from source"
done <<'ARGS'
FlashLoanRouter FlashLoanRouter.sol/FlashLoanRouter.json 0x9008D19f58AAbD9eD0D60971565AA8510560ab41 0x88e01a104196caa51e10f09cf3326eb5ea3988def13e1823786a97155cf0fb62
AaveBorrower    AaveBorrower.sol/AaveBorrower.json       0x9da8B48441583a2b93e2eF8213aAD0EC0b392C69 0xb32a71421911381356f9d21b44fc8d983dbc4c023db980754bd30b620f3a04e2
ERC3156Borrower ERC3156Borrower.sol/ERC3156Borrower.json 0x9da8B48441583a2b93e2eF8213aAD0EC0b392C69 0x6926f2ce4386afa30d164655b8cacb52de47e9a3bdaa6276f6088b7c7fb21c72
ARGS
```

`93` is `Constants.SALT`; the address argument is each contract's constructor arg (settlement for the router, router for the borrowers).

### 3. `networks.json` is reproducible
No changes expected in networks.json after generating the file
```sh
bash script/generate-networks-file.sh | diff - networks.json
```

